### PR TITLE
refactor(initialize.sh): Skip .bak for symlinks

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -50,10 +50,17 @@ link_dotfiles() {
             continue
         fi
 
-        # Backup existing file or symlink before creating a new one
+        # If destination exists, handle it
         if [ -e "$dest_path" ] || [ -L "$dest_path" ]; then
-            echo "Backing up existing file at $dest_path to $dest_path.bak"
-            mv "$dest_path" "$dest_path.bak"
+            # If it's a symlink, just remove it.
+            if [ -L "$dest_path" ]; then
+                echo "Removing existing symlink at $dest_path"
+                rm "$dest_path"
+            else
+                # Otherwise, it's a file or directory, so back it up.
+                echo "Backing up existing file at $dest_path to $dest_path.bak"
+                mv "$dest_path" "$dest_path.bak"
+            fi
         fi
 
         echo "Linking $source_path to $dest_path"


### PR DESCRIPTION
Modify the symlinking logic in `initialize.sh`.

Previously, the script would back up any existing file or symlink at the destination by renaming it with a `.bak` extension.

This change alters the behavior to first check if the destination is a symlink. If it is, the script now removes the existing symlink instead of creating a backup. If the destination is a regular file or directory, the original backup behavior is preserved.

This prevents the creation of `.bak` files for pre-existing symlinks during initialization.