### PR TITLE
feat: make gitconfig compatible with windows

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -6,14 +6,17 @@
 [github]
   user = 9renpoto
 [ghq]
-  root = ~/src
+  root = "{{ .chezmoi.homeDir }}/src"
 [core]
-  excludesfile = ~/.config/git/ignore
+  excludesfile = "{{ .chezmoi.homeDir }}/.config/git/ignore"
 [filter "lfs"]
   clean = git-lfs clean -- %f
   smudge = git-lfs smudge -- %f
   required = true
   process = git-lfs filter-process
+[init]
+	defaultBranch = main
+{{ if not (eq .chezmoi.os "windows") -}}
 [core]
   pager = delta
   editor = nvim
@@ -26,5 +29,4 @@
   commit-decoration-style = bold yellow box ul
   file-style = bold yellow ul
   file-decoration-style = none
-[init]
-	defaultBranch = main
+{{ end -}}


### PR DESCRIPTION
Converted dot_gitconfig to a chezmoi template (dot_gitconfig.tmpl) to support multiple operating systems.

- Replaced the hardcoded tilde (~) with `{{ .chezmoi.homeDir }}` for cross-platform home directory resolution.
- Wrapped Unix-specific configurations (delta, nvim) in a conditional block to exclude them on Windows.
- This ensures that the gitconfig is portable and does not cause errors on Windows systems where tools like delta or nvim may not be installed.