### PR TITLE
feat(ssh): Manage SSH config for github.com with chezmoi

### DIFF
--- a/dot_config/chezmoi/data.toml.sample
+++ b/dot_config/chezmoi/data.toml.sample
@@ -1,0 +1,8 @@
+# This is a sample data file for chezmoi.
+# To use it, copy it to "data.toml" in the same directory
+# and uncomment/edit the values you want to override.
+
+[ssh]
+# You can override the default path for the GitHub SSH key here.
+# For example:
+# github_identity_file = "~/.ssh/github_personal_key"

--- a/private_dot_ssh/config.tmpl
+++ b/private_dot_ssh/config.tmpl
@@ -1,0 +1,5 @@
+Host github.com
+  HostName github.com
+  User git
+  IdentityFile {{ .ssh.github_identity_file | default "~/.ssh/id_ed25519" }}
+  IdentitiesOnly yes


### PR DESCRIPTION
This commit introduces chezmoi management for the `~/.ssh/config` file to configure connections to github.com.

The configuration is stored in `private_dot_ssh/config.tmpl`. The `private_` prefix ensures that `chezmoi` will create the `~/.ssh/config` file with secure permissions (600).

The `IdentityFile` path is made configurable via a `chezmoi` data variable, `ssh.github_identity_file`, with `~/.ssh/id_ed25519` as the default. A sample data file, `dot_config/chezmoi/data.toml.sample`, is provided to demonstrate how to customize this value.

The private key itself is not managed by chezmoi, allowing it to be managed by other tools like `gh` or `ssh-keygen` directly.