### PR TITLE
refactor(chezmoi): Enforce using chezmoi.toml for configuration

### DIFF
--- a/chezmoi.toml
+++ b/chezmoi.toml
@@ -1,0 +1,6 @@
+# This file is a placeholder. chezmoi will use data from this file to
+# populate templates. For this repository, you must at least provide
+# an email address.
+#
+# For example:
+# email = "your.email@example.com"

--- a/dot_chezmoi.toml.tmpl
+++ b/dot_chezmoi.toml.tmpl
@@ -2,5 +2,7 @@
 # To use it, copy it to "data.toml" in the same directory
 # and uncomment/edit the values you want to override.
 
+# email = "your.email@example.com"
+
 [ssh]
 github_identity_file = "~/.ssh/id_ed25519" # Override if you use a different key

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,6 +1,6 @@
 [user]
   name = Keisuke Umeno
-  email = {{ if hasKey . "email" }}{{ .email }}{{ else }}9renpoto@gmail.com{{ end }}
+  email = {{ required "email not set in chezmoi.toml" .email }}
 [color]
   ui = auto
 [github]


### PR DESCRIPTION
This change modifies the chezmoi setup to require user-specific configuration to be set in a `chezmoi.toml` file, rather than relying on default values within the templates.

- The `dot_gitconfig.tmpl` now uses the `required` function to ensure that the user's email address is set.
- The sample data file has been renamed to `dot_chezmoi.toml.tmpl` and now serves as a template for the user's `~/.chezmoi.toml`.
- A placeholder `chezmoi.toml` file has been added to the root of the repository to make the configuration more explicit.