### PR TITLE
feat(chezmoi): Ignore gitconfig in devcontainer

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -13,3 +13,8 @@ config/nvim
 
 # Development artifacts
 .git/
+
+# Devcontainer-specific ignores
+{{ if (env "REMOTE_CONTAINERS") == "true" -}}
+dot_gitconfig.tmpl
+{{ end -}}


### PR DESCRIPTION
Adds a condition to `.chezmoiignore` to prevent `chezmoi` from installing the `.gitconfig` file when running inside a VS Code devcontainer.

This is useful for scenarios where the git configuration is managed natively by the devcontainer environment.