### PR TITLE
fix: fix clipboard corruption in tmux + zsh environment

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -1,12 +1,9 @@
 [".config/nvim"]
 type = "git-repo"
 url = "https://github.com/9renpoto/astronvim_config.git"
-branch = "main"
 refreshPeriod = "168h"
-exact = true
 
 [".tmux/plugins/tpm"]
 type = "git-repo"
 url = "https://github.com/tmux-plugins/tpm"
 refreshPeriod = "168h"
-exact = true

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -10,9 +10,12 @@ set -g status-bg "colour238"
 set -g status-fg "colour255"
 
 set -gq focus-events on
-set -gq terminal-overrides 'xterm:colors=256'
 set -sg escape-time 10
-set-option -gq default-terminal screen-256color
+set-option -g default-terminal "tmux-256color"
+set-option -ga terminal-overrides ",alacritty:RGB"
+set-option -ga terminal-overrides ",tmux-256color:RGB"
+set -g set-clipboard on
+set -g allow-passthrough on
 
 if-shell 'test -n "$SHELL"' 'set -g default-shell "$SHELL"' 'set -g default-shell "/bin/zsh"'
 


### PR DESCRIPTION
- Change default-terminal from screen-256color to tmux-256color to fix bracketed paste mode and OSC 52 clipboard support
- Add terminal-overrides for alacritty RGB support
- Enable set-clipboard and allow-passthrough for proper clipboard sync
- Remove deprecated branch and exact fields from .chezmoiexternal.toml that were breaking chezmoi apply in v2.70.1