### PR TITLE
feat(ssh): add homelabs vmware host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,17 @@ For example, to change the Git email address:
     github_identity_file = "~/.ssh/your_custom_key"
   ```
 
-- Templates such as `private_dot_ssh/config.tmpl` read `data.ssh.github_identity_file`, falling back to `~/.ssh/id_ed25519` when nothing is defined. This keeps the SSH config portable while letting each environment opt into a different key path.
+- To manage access to a VMware guest provisioned from `9renpoto/homelabs`, add a host-specific block:
+
+  ```toml
+  [data.ssh.homelabs_vmware]
+    host_name = "192.168.10.20"
+    user = "ubuntu"
+    port = 22
+    identity_file = "~/.ssh/homelabs-vmware"
+  ```
+
+- `private_dot_ssh/config.tmpl` renders `Host github.com` and, when `data.ssh.homelabs_vmware.host_name` is set, also renders `Host homelabs-vmware`. Both entries fall back to `~/.ssh/id_ed25519` when no `identity_file` override is defined.
 
 ### Secret Management
 
@@ -72,6 +82,7 @@ This script will prompt you for:
 - WakaTime API key (optional)
 - Email address override (optional)
 - Custom SSH key path (optional)
+- homelabs VMware HostName/IP, user, port, and SSH key path (optional)
 - Machine profile (optional)
 
 #### Manual Setup
@@ -88,11 +99,17 @@ Alternatively, manually create or edit `~/.config/chezmoi/chezmoi.toml`:
 [data.ssh]
   github_identity_file = "~/.ssh/your_custom_key"
 
+[data.ssh.homelabs_vmware]
+  host_name = "192.168.10.20"
+  user = "ubuntu"
+  port = 22
+  identity_file = "~/.ssh/homelabs-vmware"
+
 [data.machine]
   profile = "dev"
 ```
 
-After configuration, run `chezmoi apply` to generate your dotfiles with the provided values.
+After configuration, run `chezmoi apply` to generate your dotfiles with the provided values. If `data.ssh.homelabs_vmware.host_name` is set, you can connect with `ssh homelabs-vmware`.
 
 **Important**: Never commit `~/.config/chezmoi/chezmoi.toml` to version control. This file should remain local to each machine.
 

--- a/private_dot_ssh/config.tmpl
+++ b/private_dot_ssh/config.tmpl
@@ -1,6 +1,15 @@
-{{- $githubIdentityFile := .ssh.github_identity_file -}}
+{{- $githubIdentityFile := or .ssh.github_identity_file "~/.ssh/id_ed25519" -}}
 Host github.com
   HostName github.com
   User git
   IdentityFile {{$githubIdentityFile}}
   IdentitiesOnly yes
+
+{{- with .ssh.homelabs_vmware }}
+{{- if .host_name }}
+{{ printf "\nHost homelabs-vmware\n  HostName %s\n" .host_name -}}
+{{- if .user }}{{ printf "  User %s\n" .user -}}{{ end -}}
+{{- if .port }}{{ printf "  Port %v\n" .port -}}{{ end -}}
+{{ printf "  IdentityFile %s\n  IdentitiesOnly yes\n" (or .identity_file "~/.ssh/id_ed25519") -}}
+{{- end }}
+{{- end }}

--- a/setup-chezmoi-config.sh
+++ b/setup-chezmoi-config.sh
@@ -68,6 +68,23 @@ main() {
     github_ssh_key=${github_ssh_key:-~/.ssh/id_ed25519}
     echo
 
+    # homelabs VMware SSH config (optional)
+    read -rp "Enter HostName or IP for homelabs VMware (optional): " homelabs_vmware_host_name
+    echo
+
+    if [ -n "${homelabs_vmware_host_name:-}" ]; then
+        read -rp "Enter SSH user for homelabs VMware (optional): " homelabs_vmware_user
+        echo
+
+        read -rp "Enter SSH port for homelabs VMware [22]: " homelabs_vmware_port
+        homelabs_vmware_port=${homelabs_vmware_port:-22}
+        echo
+
+        read -rp "Enter SSH key path for homelabs VMware [~/.ssh/homelabs-vmware]: " homelabs_vmware_identity_file
+        homelabs_vmware_identity_file=${homelabs_vmware_identity_file:-~/.ssh/homelabs-vmware}
+        echo
+    fi
+
     # Machine profile (optional)
     read -rp "Enter machine profile (e.g., dev, work, personal) [dev]: " machine_profile
     machine_profile=${machine_profile:-dev}
@@ -101,6 +118,24 @@ main() {
             echo ""
             echo "[data.ssh]"
             echo "  github_identity_file = \"$github_ssh_key\""
+        fi
+
+        if [ -n "${homelabs_vmware_host_name:-}" ]; then
+            echo ""
+            echo "[data.ssh.homelabs_vmware]"
+            echo "  host_name = \"$homelabs_vmware_host_name\""
+
+            if [ -n "${homelabs_vmware_user:-}" ]; then
+                echo "  user = \"$homelabs_vmware_user\""
+            fi
+
+            if [ -n "${homelabs_vmware_port:-}" ]; then
+                echo "  port = $homelabs_vmware_port"
+            fi
+
+            if [ -n "${homelabs_vmware_identity_file:-}" ]; then
+                echo "  identity_file = \"$homelabs_vmware_identity_file\""
+            fi
         fi
 
         # Machine profile


### PR DESCRIPTION
## Summary
- add optional chezmoi data for a `homelabs-vmware` SSH host entry
- extend the setup script to capture homelabs VMware SSH settings
- document the new configuration and generated SSH alias

## Validation
- shellcheck setup-chezmoi-config.sh
- bash .devcontainer/scripts/check-chezmoi.sh
- chezmoi execute-template --file private_dot_ssh/config.tmpl --source . --working-tree . --override-data ...