### PR TITLE
chore: remove homelabs_vmware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,11 @@ Alternatively, manually create or edit `~/.config/chezmoi/chezmoi.toml`:
 [data.ssh]
   github_identity_file = "~/.ssh/your_custom_key"
 
-[data.ssh.homelabs_vmware]
-  host_name = "192.168.10.20"
-  user = "ubuntu"
-  port = 22
-  identity_file = "~/.ssh/homelabs-vmware"
-
 [data.machine]
   profile = "dev"
 ```
 
-After configuration, run `chezmoi apply` to generate your dotfiles with the provided values. If `data.ssh.homelabs_vmware.host_name` is set, you can connect with `ssh homelabs-vmware`.
+After configuration, run `chezmoi apply` to generate your dotfiles with the provided values.
 
 **Important**: Never commit `~/.config/chezmoi/chezmoi.toml` to version control. This file should remain local to each machine.
 

--- a/private_dot_ssh/config.tmpl
+++ b/private_dot_ssh/config.tmpl
@@ -4,12 +4,3 @@ Host github.com
   User git
   IdentityFile {{$githubIdentityFile}}
   IdentitiesOnly yes
-
-{{- with .ssh.homelabs_vmware }}
-{{- if .host_name }}
-{{ printf "\nHost homelabs-vmware\n  HostName %s\n" .host_name -}}
-{{- if .user }}{{ printf "  User %s\n" .user -}}{{ end -}}
-{{- if .port }}{{ printf "  Port %v\n" .port -}}{{ end -}}
-{{ printf "  IdentityFile %s\n  IdentitiesOnly yes\n" (or .identity_file "~/.ssh/id_ed25519") -}}
-{{- end }}
-{{- end }}

--- a/setup-chezmoi-config.sh
+++ b/setup-chezmoi-config.sh
@@ -68,23 +68,6 @@ main() {
     github_ssh_key=${github_ssh_key:-~/.ssh/id_ed25519}
     echo
 
-    # homelabs VMware SSH config (optional)
-    read -rp "Enter HostName or IP for homelabs VMware (optional): " homelabs_vmware_host_name
-    echo
-
-    if [ -n "${homelabs_vmware_host_name:-}" ]; then
-        read -rp "Enter SSH user for homelabs VMware (optional): " homelabs_vmware_user
-        echo
-
-        read -rp "Enter SSH port for homelabs VMware [22]: " homelabs_vmware_port
-        homelabs_vmware_port=${homelabs_vmware_port:-22}
-        echo
-
-        read -rp "Enter SSH key path for homelabs VMware [~/.ssh/homelabs-vmware]: " homelabs_vmware_identity_file
-        homelabs_vmware_identity_file=${homelabs_vmware_identity_file:-~/.ssh/homelabs-vmware}
-        echo
-    fi
-
     # Machine profile (optional)
     read -rp "Enter machine profile (e.g., dev, work, personal) [dev]: " machine_profile
     machine_profile=${machine_profile:-dev}
@@ -166,6 +149,11 @@ main() {
     echo "  ${CHEZMOI_CONFIG_FILE}"
     echo
     info "To apply your dotfiles with this configuration:"
+    echo "  chezmoi apply"
+}
+
+main "$@"
+ dotfiles with this configuration:"
     echo "  chezmoi apply"
 }
 


### PR DESCRIPTION
Removed homelabs_vmware support from SSH config, setup script, and README as it is no longer needed.