### PR TITLE
feat(skills): add automated installation for GitHub CLI agent skills and cleanup

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -3,9 +3,11 @@ AGENTS.md
 Brewfile
 README.md
 SECURITY.md
+Skillsfile
 initialize.sh
 lefthook.yml
 .gitignore
+
 
 # Managed by package managers
 config/fish

--- a/Brewfile
+++ b/Brewfile
@@ -1,24 +1,19 @@
 tap 'neovim/neovim'
-tap 'fwdcloudsec/granted'
-tap "songmu/tap"
 
-cask "1password"
-cask "antigravity-cli"
-cask "gather"
-cask "orbstack"
-cask "slack"
+cask '1password'
 cask 'alacritty'
 cask 'ankerwork'
+cask 'antigravity-cli'
 cask 'bitwarden'
-cask 'copilot-cli'
 cask 'firefox@nightly', args: { language: 'en' }
 cask 'font-jetbrains-mono-nerd-font'
+cask 'gather'
 cask 'gcloud-cli'
 cask 'google-chrome'
 cask 'obsidian'
-cask 'visual-studio-code'
+cask 'orbstack'
+cask 'slack'
 
-brew "songmu/tap/ecschedule"
 brew 'act'
 brew 'actionlint'
 brew 'antidote'
@@ -26,11 +21,11 @@ brew 'awscli'
 brew 'bat'
 brew 'carapace'
 brew 'chezmoi'
+brew 'cspell'
 brew 'devcontainer'
 brew 'direnv'
 brew 'eza'
 brew 'fd'
-brew 'fwdcloudsec/granted/granted'
 brew 'fzf'
 brew 'gh'
 brew 'ghq'
@@ -51,3 +46,4 @@ brew 'stylua'
 brew 'tig'
 brew 'tmux'
 brew 'typos-cli'
+brew 'zig'

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ For example, to change the Git email address:
 ### Environment-Specific Data
 
 - Global defaults live in `chezmoidata.toml`; platform-specific files such as `chezmoidata.darwin.toml.tmpl` and `chezmoidata.linux.toml` layer on automatic values (e.g., the Homebrew prefix).
-- Host-specific tweaks can be added by extending the override maps inside the platform templates or by adding per-host data files that follow chezmoi's naming (for example `chezmoidata.<hostname>.toml`).
 - Sensitive or machine-local overrides can stay outside the repo: use `~/.config/chezmoi/chezmoi.toml` and nest keys under `[data]` to match the structure in `chezmoidata`. For the GitHub SSH key, set:
 
   ```toml
@@ -54,17 +53,7 @@ For example, to change the Git email address:
     github_identity_file = "~/.ssh/your_custom_key"
   ```
 
-- To manage access to a VMware guest provisioned from `9renpoto/homelabs`, add a host-specific block:
-
-  ```toml
-  [data.ssh.homelabs_vmware]
-    host_name = "192.168.10.20"
-    user = "ubuntu"
-    port = 22
-    identity_file = "~/.ssh/homelabs-vmware"
-  ```
-
-- `private_dot_ssh/config.tmpl` renders `Host github.com` and, when `data.ssh.homelabs_vmware.host_name` is set, also renders `Host homelabs-vmware`. Both entries fall back to `~/.ssh/id_ed25519` when no `identity_file` override is defined.
+- `private_dot_ssh/config.tmpl` renders `Host github.com` and falls back to `~/.ssh/id_ed25519` when no `identity_file` override is defined.
 
 ### Secret Management
 
@@ -82,7 +71,6 @@ This script will prompt you for:
 - WakaTime API key (optional)
 - Email address override (optional)
 - Custom SSH key path (optional)
-- homelabs VMware HostName/IP, user, port, and SSH key path (optional)
 - Machine profile (optional)
 
 #### Manual Setup

--- a/Skillsfile
+++ b/Skillsfile
@@ -1,0 +1,16 @@
+# GitHub CLI Agent Skills to install
+# Format: <owner/repo> <skill_name> [optional flags]
+#
+# If no flags are provided, skills are installed for claude-code, gemini-cli, and github-copilot at the user scope.
+
+# Core Skills from github/awesome-copilot
+github/awesome-copilot context-map
+github/awesome-copilot documentation-writer
+github/awesome-copilot doublecheck
+github/awesome-copilot gh-cli
+github/awesome-copilot git-commit
+github/awesome-copilot github-issues
+
+# Engineering Skills from mattpocock/skills
+mattpocock/skills engineering/grill-with-docs
+mattpocock/skills productivity/grill-me

--- a/private_dot_ssh/config.tmpl
+++ b/private_dot_ssh/config.tmpl
@@ -1,4 +1,5 @@
-{{- $githubIdentityFile := or .ssh.github_identity_file "~/.ssh/id_ed25519" -}}
+{{- $ssh := default (dict) (get . "ssh") -}}
+{{- $githubIdentityFile := default "~/.ssh/id_ed25519" (get $ssh "github_identity_file") -}}
 Host github.com
   HostName github.com
   User git

--- a/run_onchange_install-skills.sh.tmpl
+++ b/run_onchange_install-skills.sh.tmpl
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Skillsfile hash: {{ include "Skillsfile" | sha256sum }}
+
+if command -v gh >/dev/null 2>&1; then
+    echo "Installing/updating gh skills from Skillsfile..."
+    while read -r line; do
+        # Ignore comments and empty lines
+        [[ "$line" =~ ^#.*$ ]] || [[ -z "$line" ]] && continue
+        
+        # Check if the line already specifies agent/scope flags
+        if [[ "$line" =~ "--agent" ]] || [[ "$line" =~ "--scope" ]] || [[ "$line" =~ "--dir" ]]; then
+            echo "Installing skill (explicit flags): $line"
+            gh skill install $line || true
+        else
+            echo "Installing skill (default agents/scope): $line"
+            for agent in claude-code gemini-cli github-copilot; do
+                gh skill install $line --agent "$agent" --scope user || true
+            done
+        fi
+    done < "{{ joinPath .chezmoi.sourceDir "Skillsfile" }}"
+fi

--- a/setup-chezmoi-config.sh
+++ b/setup-chezmoi-config.sh
@@ -103,24 +103,6 @@ main() {
             echo "  github_identity_file = \"$github_ssh_key\""
         fi
 
-        if [ -n "${homelabs_vmware_host_name:-}" ]; then
-            echo ""
-            echo "[data.ssh.homelabs_vmware]"
-            echo "  host_name = \"$homelabs_vmware_host_name\""
-
-            if [ -n "${homelabs_vmware_user:-}" ]; then
-                echo "  user = \"$homelabs_vmware_user\""
-            fi
-
-            if [ -n "${homelabs_vmware_port:-}" ]; then
-                echo "  port = $homelabs_vmware_port"
-            fi
-
-            if [ -n "${homelabs_vmware_identity_file:-}" ]; then
-                echo "  identity_file = \"$homelabs_vmware_identity_file\""
-            fi
-        fi
-
         # Machine profile
         if [ -n "${machine_profile:-}" ]; then
             echo ""
@@ -149,11 +131,6 @@ main() {
     echo "  ${CHEZMOI_CONFIG_FILE}"
     echo
     info "To apply your dotfiles with this configuration:"
-    echo "  chezmoi apply"
-}
-
-main "$@"
- dotfiles with this configuration:"
     echo "  chezmoi apply"
 }
 


### PR DESCRIPTION
## Intent
This PR sets up automated installation for GitHub CLI agent skills and cleans up remaining references to the deprecated `homelabs_vmware` support.

- Added `Skillsfile` with a list of default and custom GitHub CLI agent skills.
- Added `run_onchange_install-skills.sh.tmpl` to automate skill installations on change via chezmoi.
- Ignored `Skillsfile` in `.chezmoiignore`.
- Cleaned up packages and dependencies in `Brewfile`.
- Removed remaining references to `homelabs_vmware` in `README.md` and `setup-chezmoi-config.sh`.
- Fixed a syntax error (duplicated blocks) in `setup-chezmoi-config.sh` that was causing shellcheck to fail.
- Made SSH identity lookup safer in `private_dot_ssh/config.tmpl`.

## Validation Steps
- Verified that all chezmoi templates render correctly without errors:
  ```sh
  bash .devcontainer/scripts/check-chezmoi.sh
  ```
  Outcome: Template verification and dry-run completed successfully.
- Ran static analysis on the modified script files:
  ```sh
  shellcheck setup-chezmoi-config.sh
  shellcheck initialize.sh
  ```
  Outcome: `shellcheck` completed successfully with no errors.
