### PR TITLE
chore: manage herdr config with chezmoi

### DIFF
--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -1,0 +1,7 @@
+onboarding = false
+
+[ui.toast]
+delivery = "herdr"
+
+[ui]
+show_agent_labels_on_pane_borders = true

--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -1,7 +1,21 @@
 onboarding = false
 
-[ui.toast]
-delivery = "herdr"
+[theme]
+# Follow macOS light/dark appearance
+auto_switch = true
+dark_name = "dracula"
+light_name = "catppuccin-latte"
 
 [ui]
 show_agent_labels_on_pane_borders = true
+# Surface agents that need attention first
+agent_panel_sort = "priority"
+
+[ui.toast]
+# Deliver completion / input-request notifications to macOS Notification Center
+delivery = "system"
+
+[experimental]
+# Japanese IME support on macOS
+reveal_hidden_cursor_for_cjk_ime = true
+switch_ascii_input_source_in_prefix = true


### PR DESCRIPTION
## 概要

`~/.config/herdr/config.toml` を chezmoi 管理下に追加しました。

## 変更点

- `dot_config/herdr/config.toml` を追加（既存の `dot_config/` 配下の慣習に合わせて配置）

🤖 Generated with [Claude Code](https://claude.com/claude-code)