### PR TITLE
feat(ghostty): add ghostty with auto light/dark theme

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -10,6 +10,7 @@ cask 'firefox@nightly', args: { language: 'en' }
 cask 'font-jetbrains-mono-nerd-font'
 cask 'gather'
 cask 'gcloud-cli'
+cask 'ghostty'
 cask 'google-chrome'
 cask 'obsidian'
 cask 'orbstack'

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,0 +1,42 @@
+# Ghostty config
+# 設定リファレンス: https://ghostty.org/docs/config
+# 全オプション: `ghostty +show-config --default --docs`
+# 注意: 行末インラインコメント（値 # コメント）は不可。コメントは行単位で。
+
+# ── フォント ───────────────────────────────
+font-family = "JetBrainsMono Nerd Font"
+font-size = 13
+# macOSで文字を太く・くっきり
+font-thicken = true
+# 行間を少し広げて読みやすく
+adjust-cell-height = 8%
+
+# ── テーマ（OS の外観に自動追従）─────────────
+# dark = Dracula（現行 Alacritty と同系）、light = Catppuccin Latte。
+# テーマ名一覧・プレビューは `ghostty +list-themes`
+theme = light:Catppuccin Latte,dark:Dracula
+# 低すぎるコントラストを自動で持ち上げ、読めない色を防ぐ
+minimum-contrast = 1.1
+
+# ── ウィンドウ ─────────────────────────────
+# 内側の余白
+window-padding-x = 8
+window-padding-y = 8
+# 背景の透過とすりガラス（macOS）
+background-opacity = 0.95
+background-blur = true
+# macOS のタイトルバー: native / transparent / tabs / hidden
+macos-titlebar-style = transparent
+# 終了時のウィンドウ状態を復元
+window-save-state = always
+
+# ── カーソル ───────────────────────────────
+cursor-style = block
+cursor-style-blink = true
+mouse-hide-while-typing = true
+
+# ── その他 ─────────────────────────────────
+# 選択で自動コピー
+copy-on-select = clipboard
+# スクロールバック上限（約100MB。デフォルトは約10MB）
+scrollback-limit = 100000000


### PR DESCRIPTION
## What

Add [Ghostty](https://ghostty.org) alongside the existing Alacritty setup so it can be trialed before deciding which terminal to keep.

- **Brewfile**: add `cask 'ghostty'`
- **dot_config/ghostty/config** (new):
  - Font matches Alacritty — JetBrainsMono Nerd Font
  - `theme = light:Catppuccin Latte,dark:Dracula` — auto-switches with the OS appearance
  - Tuned `font-thicken`, `adjust-cell-height`, `minimum-contrast`, opacity/blur, `scrollback-limit`

## Why

Alacritty has **no native OS light/dark theme following** — it would require an external trigger (e.g. a launchd `WatchPaths` agent) to swap imported theme files. Ghostty supports this natively with a single `theme = light:...,dark:...` line, so it's worth trialing.

## Notes for reviewers

- Alacritty config is **left untouched**, so switching back is trivial.
- Ghostty does **not** allow trailing inline comments (`value # comment`); comments are line-only. Config validated with `ghostty +validate-config` (no errors).
- Keybindings and quick-terminal intentionally left at defaults for now.
- Follow-up once decided: either remove Alacritty (cask + `dot_config/alacritty/`) or drop Ghostty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)