### PR TITLE
chore: drive herdr colors from the ghostty terminal palette

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -12,9 +12,11 @@ font-thicken = true
 adjust-cell-height = 8%
 
 # ── テーマ（OS の外観に自動追従）─────────────
-# dark = Dracula（現行 Alacritty と同系）、light = Catppuccin Latte。
+# dark = Dracula、light = Kanagawa Lotus。
+# herdr は light_name = "terminal" で端末パレットに委譲するため、
+# ライトの見え方はこの ghostty テーマが全て決める（白浮きの二層問題を回避）。
 # テーマ名一覧・プレビューは `ghostty +list-themes`
-theme = light:Catppuccin Latte,dark:Dracula
+theme = light:Kanagawa Lotus,dark:Dracula
 # 低すぎるコントラストを自動で持ち上げ、読めない色を防ぐ
 minimum-contrast = 1.1
 

--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -1,10 +1,12 @@
 onboarding = false
 
 [theme]
-# Follow macOS light/dark appearance
+# Defer to the terminal (ghostty) palette in both light and dark, so herdr
+# never paints its own theme over the terminal (avoids the light-mode white
+# background bleed). ghostty handles the actual light/dark switching.
 auto_switch = true
-dark_name = "dracula"
-light_name = "catppuccin-latte"
+dark_name = "terminal"
+light_name = "terminal"
 
 [ui]
 show_agent_labels_on_pane_borders = true


### PR DESCRIPTION
## What

- **herdr**: set `dark_name` and `light_name` to `"terminal"` so herdr defers entirely to the ghostty palette in both light and dark.
- **ghostty**: switch the light theme from Catppuccin Latte to `Kanagawa Lotus` (dark stays Dracula).
- Refresh the surrounding comments (drop the stale Alacritty note, document why herdr uses the terminal palette).

## Why

In light mode herdr painted its own theme over the terminal, leaving white-background bleed and hard-to-read text (e.g. dialogs, diff blocks). Letting herdr use the `terminal` theme collapses the two color layers into one, so the terminal theme alone decides how everything looks and the white bleed is gone by construction. Kanagawa Lotus gives a comfortable single light appearance.

## Notes for reviewer

- With both herdr names set to `terminal`, herdr's `auto_switch` is effectively a no-op — ghostty handles the light/dark switching. Left in place as harmless.
- Applied live via `herdr server reload-config`; ghostty picks it up on config reload (`Cmd+Shift+,`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)