### PR TITLE
fix(fonts): improve Japanese font rendering in ghostty and alacritty

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -10,7 +10,9 @@ cask 'chatgpt'
 cask 'claude'
 cask 'codexbar'
 cask 'firefox@nightly', args: { language: 'en' }
-cask 'font-jetbrains-mono-nerd-font'
+# pkgインストーラでsudoパスワードを要求されるため手動インストールが必要
+cask 'font-sf-mono'
+cask 'font-udev-gothic-nf'
 cask 'gather'
 cask 'gcloud-cli'
 cask 'ghostty'

--- a/dot_config/alacritty/alacritty.toml
+++ b/dot_config/alacritty/alacritty.toml
@@ -1,14 +1,14 @@
 
 [font.bold]
-family = "JetBrainsMono Nerd Font"
+family = "UDEV Gothic NF"
 style = "Bold"
 
 [font.italic]
-family = "JetBrainsMono Nerd Font"
+family = "UDEV Gothic NF"
 style = "Italic"
 
 [font.normal]
-family = "JetBrainsMono Nerd Font"
+family = "UDEV Gothic NF"
 style = "Regular"
 
 [general]

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -4,7 +4,10 @@
 # 注意: 行末インラインコメント（値 # コメント）は不可。コメントは行単位で。
 
 # ── フォント ───────────────────────────────
-font-family = "JetBrainsMono Nerd Font"
+# 英数は SF Mono、日本語は Hiragino Sans（ヒラギノ角ゴ）でmacOS純正の見た目に。
+# Nerd Font 記号(starship のアイコン等)は ghostty 内蔵の Symbols Nerd Font にフォールバック。
+font-family = "SF Mono"
+font-family = "Hiragino Sans"
 font-size = 13
 # macOSで文字を太く・くっきり
 font-thicken = true


### PR DESCRIPTION
## Summary
- `JetBrainsMono Nerd Font` has no Japanese glyphs, so CJK text fell back to a mismatched font with inconsistent metrics, causing blurry/uneven rendering in ghostty (used with herdr) and alacritty.
- ghostty: switch to `SF Mono` + `Hiragino Sans` for a native macOS look. ghostty's built-in Symbols Nerd Font fallback keeps starship's Nerd Font icons (git branch, folder, powerline separators, etc.) working.
- alacritty: switch to `UDEV Gothic NF` (JetBrains Mono + BIZ UDGothic composite). alacritty has no built-in Nerd Font fallback, so a single font that bundles Nerd Font glyphs is required there to keep starship icons intact.
- Brewfile: replace `font-jetbrains-mono-nerd-font` with `font-sf-mono` (note: pkg installer requires sudo, manual install) and `font-udev-gothic-nf`.

## Test plan
- [x] Verified glyph resolution via `ghostty +show-face` for ASCII, Japanese (漢字/カナ/読点), starship Nerd Font icons, and powerline separators against the live config — all resolve to the intended font/fallback.
- [x] Verified all 4 style variants (Regular/Bold/Italic/BoldItalic) resolve correctly for both SF Mono and UDEV Gothic NF.
- [x] `chezmoi apply --dry-run` reviewed before applying; applied and confirmed live config files match.
- [x] `brew bundle check --file=Brewfile` shows no new unmet dependencies (pre-existing untrusted-tap warning for `songmu/tap/ecschedule` is unrelated).