### PR TITLE
feat(windows): add winget bootstrap

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -4,7 +4,9 @@ Brewfile
 README.md
 SECURITY.md
 initialize.sh
+initialize.ps1
 lefthook.yml
+winget-packages.json
 .gitignore
 
 # Managed by package managers

--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ Before running `chezmoi apply` on macOS, make sure the base toolchain is ready:
 - Install Homebrew if it's missing (see [brew.sh](https://brew.sh/) for the latest install command)
 - Confirm Homebrew works: `brew doctor`
 
+### Windows Preparation
+
+Run the Windows bootstrap from PowerShell in a development clone:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass
+.\initialize.ps1
+```
+
+The script imports `winget-packages.json`, refreshes `PATH` for the current
+process, and applies the local source state with `chezmoi`. Use
+`.\initialize.ps1 -SkipPackages` to reapply only the dotfiles, or
+`.\initialize.ps1 -SkipApply` to install only the packages. It also configures
+the ghq root as `%USERPROFILE%\src` on Windows and the corresponding
+`/mnt/<drive>/Users/<user>/src` path in the default WSL distribution. Override
+the location with `.\initialize.ps1 -GhqRoot D:\src` when needed.
+
 ## Configuration
 
 Some configurations can be customized using variables. Create a `~/.config/chezmoi/chezmoi.toml` file to override default values.
@@ -148,6 +165,7 @@ Use `chezmoidata.darwin.toml.tmpl` as a starting point when you need to pin macO
 - `chezmoi update --apply` pulls the latest repository changes and reapplies them.
 - `brew bundle --file=Brewfile` keeps CLI/GUI packages in sync with the tracked Brewfile.
 - `brew bundle check --file=Brewfile` inspects for drift; pair with `brew bundle cleanup --file=Brewfile` to prune unused packages.
+- `winget import --import-file winget-packages.json --ignore-unavailable --ignore-versions` installs the Windows toolset.
 - `lefthook run pre-commit --all-files` runs Secretlint locally; enable the hook permanently with `lefthook install`.
 
 ## Working Locally

--- a/initialize.ps1
+++ b/initialize.ps1
@@ -1,0 +1,134 @@
+[CmdletBinding()]
+param(
+  [switch]$SkipPackages,
+  [switch]$SkipApply,
+  [string]$GhqRoot = (Join-Path $HOME 'src')
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Write-Info {
+  param([Parameter(Mandatory)][string]$Message)
+
+  Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Update-ProcessPath {
+  $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+  $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+  $separator = [IO.Path]::PathSeparator
+  $pathEntries = @($machinePath, $userPath, $env:Path) `
+    -split [Regex]::Escape($separator) `
+    | Where-Object { $_ } `
+    | Select-Object -Unique
+  $env:Path = $pathEntries -join $separator
+}
+
+function Initialize-ChezmoiConfig {
+  $configDirectory = Join-Path $HOME '.config\chezmoi'
+  $configPath = Join-Path $configDirectory 'chezmoi.toml'
+
+  if (Test-Path $configPath) {
+    return
+  }
+
+  Write-Info "Creating default chezmoi config at $configPath"
+  New-Item -ItemType Directory -Path $configDirectory -Force | Out-Null
+  $config = @'
+[data.ssh]
+  github_identity_file = "~/.ssh/id_ed25519"
+'@
+  [IO.File]::WriteAllText(
+    $configPath,
+    $config + [Environment]::NewLine,
+    [Text.UTF8Encoding]::new($false)
+  )
+}
+
+function Set-GhqRoot {
+  param([Parameter(Mandatory)][string]$Root)
+
+  $git = Get-Command git.exe -ErrorAction SilentlyContinue
+  if (-not $git) {
+    throw 'git.exe was not found after package installation.'
+  }
+
+  $resolvedRoot = [IO.Path]::GetFullPath($Root)
+  New-Item -ItemType Directory -Path $resolvedRoot -Force | Out-Null
+
+  $gitPath = $git.Source
+  & $gitPath config --global ghq.root ($resolvedRoot -replace '\\', '/')
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to configure the Windows ghq root at $resolvedRoot."
+  }
+  Write-Info "Windows ghq root: $resolvedRoot"
+
+  if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+    Write-Warning 'WSL was not found; skipped WSL ghq root configuration.'
+    return
+  }
+
+  $wslRootOutput = & wsl.exe --exec wslpath -a -u $resolvedRoot 2>$null
+  if ($LASTEXITCODE -ne 0 -or -not $wslRootOutput) {
+    Write-Warning 'Could not convert the Windows ghq root to a WSL path.'
+    return
+  }
+
+  $wslRoot = ($wslRootOutput | Select-Object -First 1).Trim()
+  & wsl.exe --exec mkdir -p $wslRoot
+  if ($LASTEXITCODE -ne 0) {
+    Write-Warning "Could not create the WSL ghq root at $wslRoot."
+    return
+  }
+
+  & wsl.exe --exec git config --global ghq.root $wslRoot
+  if ($LASTEXITCODE -ne 0) {
+    Write-Warning 'Git was not available in the default WSL distribution; skipped its ghq configuration.'
+    return
+  }
+  Write-Info "WSL ghq root: $wslRoot"
+}
+
+$repositoryRoot = $PSScriptRoot
+$packageManifest = Join-Path $repositoryRoot 'winget-packages.json'
+
+if (-not $SkipPackages) {
+  if (-not (Get-Command winget.exe -ErrorAction SilentlyContinue)) {
+    throw 'winget.exe was not found. Install App Installer from Microsoft Store and retry.'
+  }
+
+  Write-Info 'Installing Windows packages with winget'
+  & winget.exe import `
+    --import-file $packageManifest `
+    --ignore-unavailable `
+    --ignore-versions `
+    --accept-package-agreements `
+    --accept-source-agreements
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "winget import failed with exit code $LASTEXITCODE."
+  }
+
+  Update-ProcessPath
+}
+
+if (-not $SkipApply) {
+  $chezmoi = Get-Command chezmoi.exe -ErrorAction SilentlyContinue
+  if (-not $chezmoi) {
+    throw 'chezmoi.exe was not found. Open a new PowerShell session and run .\initialize.ps1 -SkipPackages.'
+  }
+
+  Initialize-ChezmoiConfig
+  Write-Info 'Applying dotfiles with chezmoi'
+  $chezmoiPath = $chezmoi.Source
+  & $chezmoiPath apply --source $repositoryRoot --destination $HOME
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "chezmoi apply failed with exit code $LASTEXITCODE."
+  }
+
+  Set-GhqRoot -Root $GhqRoot
+}
+
+Write-Info 'Windows dotfiles initialization complete'

--- a/winget-packages.json
+++ b/winget-packages.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://aka.ms/winget-packages.schema.2.0.json",
+  "Sources": [
+    {
+      "Packages": [
+        { "PackageIdentifier": "Alacritty.Alacritty" },
+        { "PackageIdentifier": "Amazon.AWSCLI" },
+        { "PackageIdentifier": "Bitwarden.Bitwarden" },
+        { "PackageIdentifier": "BurntSushi.ripgrep.MSVC" },
+        { "PackageIdentifier": "eza-community.eza" },
+        { "PackageIdentifier": "Git.Git" },
+        { "PackageIdentifier": "GitHub.cli" },
+        { "PackageIdentifier": "Google.Chrome" },
+        { "PackageIdentifier": "jdx.mise" },
+        { "PackageIdentifier": "jqlang.jq" },
+        { "PackageIdentifier": "junegunn.fzf" },
+        { "PackageIdentifier": "Microsoft.PowerShell" },
+        { "PackageIdentifier": "Microsoft.VisualStudioCode" },
+        { "PackageIdentifier": "Microsoft.WindowsTerminal" },
+        { "PackageIdentifier": "Neovim.Neovim" },
+        { "PackageIdentifier": "Obsidian.Obsidian" },
+        { "PackageIdentifier": "sharkdp.bat" },
+        { "PackageIdentifier": "sharkdp.fd" },
+        { "PackageIdentifier": "Starship.Starship" },
+        { "PackageIdentifier": "twpayne.chezmoi" },
+        { "PackageIdentifier": "x-motemen.ghq" }
+      ],
+      "SourceDetails": {
+        "Argument": "https://cdn.winget.microsoft.com/cache",
+        "Identifier": "Microsoft.Winget.Source_8wekyb3d8bbwe",
+        "Name": "winget",
+        "Type": "Microsoft.PreIndexed.Package"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a Windows Package Manager import manifest for the supported Windows toolset
- add a PowerShell bootstrap that installs packages, applies chezmoi, and configures a shared ghq root for Windows and WSL
- document Windows setup, reapply, package-only, and custom ghq-root workflows

## Why

Windows hosts cannot use the repository's Homebrew workflow directly. This provides a repeatable winget-based setup while keeping repositories in one location that is accessible from both Windows and WSL.

## Impact

Running `initialize.ps1` installs the listed Windows packages, creates a minimal local chezmoi configuration when needed, applies the source state, and configures `%USERPROFILE%\src` plus its corresponding WSL mount as `ghq.root`.

## Validation

- `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File initialize.ps1 -SkipPackages -SkipApply`
- parsed `winget-packages.json` with PowerShell `ConvertFrom-Json`
- verified every package identifier with `winget show --id <id> --exact`
- verified ghq 1.10.1 resolves from the winget link and both Windows and WSL report the shared root
- `git diff --cached --check`