### PR TITLE
feat(shell): manage mise and starship profiles

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -20,7 +20,7 @@ config/nvim
 
 # Preserve host-specific Git settings on Windows
 {{- if eq .chezmoi.os "windows" }}
-dot_gitconfig.tmpl
+.gitconfig
 {{ end -}}
 
 # Devcontainer-specific ignores

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -18,6 +18,11 @@ config/nvim
 # Development artifacts
 .git/
 
+# Preserve host-specific Git settings on Windows
+{{- if eq .chezmoi.os "windows" }}
+dot_gitconfig.tmpl
+{{ end -}}
+
 # Devcontainer-specific ignores
 {{- if eq (env "REMOTE_CONTAINERS") "true" }}
 dot_gitconfig.tmpl

--- a/.chezmoiscripts/run_onchange_after_install-powershell-profiles.ps1.tmpl
+++ b/.chezmoiscripts/run_onchange_after_install-powershell-profiles.ps1.tmpl
@@ -23,18 +23,41 @@ function Install-ProfileLoader {
   if (-not (Test-Path -LiteralPath $Path)) {
     if ($CreateIfMissing) {
       [IO.File]::WriteAllText($Path, $loader, $utf8WithoutBom)
+      return $true
     }
-    return
+    return $false
   }
 
-  $currentContent = (Get-Content -Raw -LiteralPath $Path).Trim()
+  $currentContent = [IO.File]::ReadAllText($Path).Trim()
   if (
     $currentContent.Length -eq 0 -or
     $currentContent -eq $legacyProfile -or
     $currentContent -eq $loader.Trim()
   ) {
     [IO.File]::WriteAllText($Path, $loader, $utf8WithoutBom)
+    return $true
   } else {
+    Write-Warning "Preserving customized PowerShell profile: $Path"
+    return $false
+  }
+}
+
+function Remove-MigratedProfileContent {
+  param(
+    [Parameter(Mandatory)][string]$Path
+  )
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return
+  }
+
+  $currentContent = [IO.File]::ReadAllText($Path).Trim()
+  if (
+    $currentContent -eq $legacyProfile -or
+    $currentContent -eq $loader.Trim()
+  ) {
+    [IO.File]::WriteAllText($Path, '', $utf8WithoutBom)
+  } elseif ($currentContent.Length -gt 0) {
     Write-Warning "Preserving customized PowerShell profile: $Path"
   }
 }
@@ -44,10 +67,12 @@ foreach ($profileDirectoryName in @('WindowsPowerShell', 'PowerShell')) {
   New-Item -ItemType Directory -Path $profileDirectory -Force | Out-Null
 
   $allHostsProfile = Join-Path $profileDirectory 'profile.ps1'
-  Install-ProfileLoader -Path $allHostsProfile -CreateIfMissing
+  $loaderInstalled = Install-ProfileLoader -Path $allHostsProfile -CreateIfMissing
 
-  $currentHostProfile = Join-Path $profileDirectory 'Microsoft.PowerShell_profile.ps1'
-  Install-ProfileLoader -Path $currentHostProfile
+  if ($loaderInstalled) {
+    $currentHostProfile = Join-Path $profileDirectory 'Microsoft.PowerShell_profile.ps1'
+    Remove-MigratedProfileContent -Path $currentHostProfile
+  }
 }
 
 Write-Host "PowerShell profiles load $sharedProfilePath"

--- a/.chezmoiscripts/run_onchange_after_install-powershell-profiles.ps1.tmpl
+++ b/.chezmoiscripts/run_onchange_after_install-powershell-profiles.ps1.tmpl
@@ -1,0 +1,54 @@
+{{ if eq .chezmoi.os "windows" -}}
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$documentsDirectory = [Environment]::GetFolderPath('MyDocuments')
+$sharedProfilePath = Join-Path $HOME '.config\powershell\profile.ps1'
+$loader = @"
+`$sharedProfilePath = Join-Path `$HOME '.config\powershell\profile.ps1'
+if (Test-Path -LiteralPath `$sharedProfilePath) {
+  . `$sharedProfilePath
+}
+"@
+$loader = $loader.Trim() + [Environment]::NewLine
+$legacyProfile = 'Invoke-Expression (&starship init powershell)'
+$utf8WithoutBom = [Text.UTF8Encoding]::new($false)
+
+function Install-ProfileLoader {
+  param(
+    [Parameter(Mandatory)][string]$Path,
+    [switch]$CreateIfMissing
+  )
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    if ($CreateIfMissing) {
+      [IO.File]::WriteAllText($Path, $loader, $utf8WithoutBom)
+    }
+    return
+  }
+
+  $currentContent = (Get-Content -Raw -LiteralPath $Path).Trim()
+  if (
+    $currentContent.Length -eq 0 -or
+    $currentContent -eq $legacyProfile -or
+    $currentContent -eq $loader.Trim()
+  ) {
+    [IO.File]::WriteAllText($Path, $loader, $utf8WithoutBom)
+  } else {
+    Write-Warning "Preserving customized PowerShell profile: $Path"
+  }
+}
+
+foreach ($profileDirectoryName in @('WindowsPowerShell', 'PowerShell')) {
+  $profileDirectory = Join-Path $documentsDirectory $profileDirectoryName
+  New-Item -ItemType Directory -Path $profileDirectory -Force | Out-Null
+
+  $allHostsProfile = Join-Path $profileDirectory 'profile.ps1'
+  Install-ProfileLoader -Path $allHostsProfile -CreateIfMissing
+
+  $currentHostProfile = Join-Path $profileDirectory 'Microsoft.PowerShell_profile.ps1'
+  Install-ProfileLoader -Path $currentHostProfile
+}
+
+Write-Host "PowerShell profiles load $sharedProfilePath"
+{{ end -}}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Keep repository text files consistent across platforms.
+* text=auto eol=lf

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ the ghq root as `%USERPROFILE%\src` on Windows and the corresponding
 `/mnt/<drive>/Users/<user>/src` path in the default WSL distribution. Override
 the location with `.\initialize.ps1 -GhqRoot D:\src` when needed.
 
+PowerShell 5.1 and PowerShell 7 load the shared
+`~/.config/powershell/profile.ps1` profile. The shared profile initializes
+Starship and activates mise. Their cross-platform configuration lives in
+`~/.config/starship.toml` and `~/.config/mise/config.toml`.
+
 ## Configuration
 
 Some configurations can be customized using variables. Create a `~/.config/chezmoi/chezmoi.toml` file to override default values.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ the ghq root as `%USERPROFILE%\src` on Windows and the corresponding
 `/mnt/<drive>/Users/<user>/src` path in the default WSL distribution. Override
 the location with `.\initialize.ps1 -GhqRoot D:\src` when needed.
 
+The winget manifest installs WakaTime CLI. To configure its API key without
+showing it in the terminal, run:
+
+```powershell
+.\initialize.ps1 -SkipPackages -ConfigureWakaTime
+```
+
+The key is stored only in the local chezmoi config, then rendered into
+`~/.wakatime.cfg`. Existing `[data.wakatime]` settings are preserved.
+The managed Neovim configuration already includes the WakaTime plugin.
+
 PowerShell 5.1 and PowerShell 7 load the shared
 `~/.config/powershell/profile.ps1` profile. The shared profile initializes
 Starship and activates mise. Their cross-platform configuration lives in

--- a/dot_config/git/dot_gitconfig
+++ b/dot_config/git/dot_gitconfig
@@ -1,2 +1,0 @@
-[ghq]
-  root = ~/src

--- a/dot_config/git/dot_gitconfig.tmpl
+++ b/dot_config/git/dot_gitconfig.tmpl
@@ -1,0 +1,4 @@
+{{- $ghq := default (dict) (get . "ghq") -}}
+{{- $ghqRoot := default "~/src" (get $ghq "root") -}}
+[ghq]
+  root = {{ $ghqRoot | quote }}

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -1,3 +1,4 @@
 [settings]
 
 [tools]
+codex = "latest"

--- a/dot_config/powershell/profile.ps1
+++ b/dot_config/powershell/profile.ps1
@@ -1,0 +1,12 @@
+if ($global:DotfilesPowerShellProfileLoaded) {
+  return
+}
+$global:DotfilesPowerShellProfileLoaded = $true
+
+if (Get-Command starship -ErrorAction SilentlyContinue) {
+  Invoke-Expression (& starship init powershell)
+}
+
+if (Get-Command mise -ErrorAction SilentlyContinue) {
+  (& mise activate pwsh) | Out-String | Invoke-Expression
+}

--- a/dot_config/powershell/profile.ps1
+++ b/dot_config/powershell/profile.ps1
@@ -1,8 +1,3 @@
-if ($global:DotfilesPowerShellProfileLoaded) {
-  return
-}
-$global:DotfilesPowerShellProfileLoaded = $true
-
 if (Get-Command starship -ErrorAction SilentlyContinue) {
   Invoke-Expression (& starship init powershell)
 }

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -1,0 +1,1 @@
+"$schema" = "https://starship.rs/config-schema.json"

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -7,13 +7,15 @@
 {{- end -}}
 {{- $core := default (dict) (get . "core") -}}
 {{- $editor := default "nvim" (get $core "editor") -}}
+{{- $ghq := default (dict) (get . "ghq") -}}
+{{- $ghqRoot := default "~/src" (get $ghq "root") -}}
 [user]
   name = Keisuke Umeno{{ if $email }}
   email = {{ $email }}{{ end }}
 [color]
   ui = auto
 [ghq]
-  root = ~/src
+  root = {{ $ghqRoot | quote }}
 [core]
   excludesfile = ~/.config/git/ignore
 [core]

--- a/initialize.ps1
+++ b/initialize.ps1
@@ -152,6 +152,30 @@ function Write-GhqConfig {
   return $resolvedRoot
 }
 
+function Add-GitConfigInclude {
+  $git = Get-Command git.exe -ErrorAction SilentlyContinue
+  if (-not $git) {
+    throw 'git.exe was not found after package installation.'
+  }
+
+  $gitProcess = Start-Process `
+    -FilePath $git.Source `
+    -ArgumentList @(
+      'config',
+      '--global',
+      '--replace-all',
+      'include.path',
+      '~/.config/git/.gitconfig'
+    ) `
+    -NoNewWindow `
+    -Wait `
+    -PassThru
+  if ($gitProcess.ExitCode -ne 0) {
+    throw 'Failed to configure the managed Git config include.'
+  }
+  Write-Info 'Windows Git config includes ~/.config/git/.gitconfig'
+}
+
 function Sync-WslGhqRoot {
   param([Parameter(Mandatory)][string]$Root)
 
@@ -224,6 +248,7 @@ if (-not $SkipApply) {
     throw "chezmoi apply failed with exit code $LASTEXITCODE."
   }
 
+  Add-GitConfigInclude
   Sync-WslGhqRoot -Root $resolvedGhqRoot
 }
 

--- a/initialize.ps1
+++ b/initialize.ps1
@@ -90,30 +90,77 @@ function Add-WakaTimeConfig {
   Write-Info 'WakaTime API key was added to the local chezmoi config.'
 }
 
-function Set-GhqRoot {
-  param([Parameter(Mandatory)][string]$Root)
-
-  $git = Get-Command git.exe -ErrorAction SilentlyContinue
-  if (-not $git) {
-    throw 'git.exe was not found after package installation.'
-  }
+function Write-GhqConfig {
+  param(
+    [Parameter(Mandatory)][string]$ConfigPath,
+    [Parameter(Mandatory)][string]$Root
+  )
 
   $resolvedRoot = [IO.Path]::GetFullPath($Root)
   New-Item -ItemType Directory -Path $resolvedRoot -Force | Out-Null
 
-  $gitPath = $git.Source
-  & $gitPath config --global ghq.root ($resolvedRoot -replace '\\', '/')
-  if ($LASTEXITCODE -ne 0) {
-    throw "Failed to configure the Windows ghq root at $resolvedRoot."
+  $normalizedRoot = $resolvedRoot -replace '\\', '/'
+  $escapedRoot = $normalizedRoot.Replace('\', '\\').Replace('"', '\"')
+  $rootSetting = "  root = `"$escapedRoot`""
+  $lines = [Collections.Generic.List[string]]::new()
+  $lines.AddRange([IO.File]::ReadAllLines($ConfigPath))
+
+  $sectionIndex = -1
+  for ($index = 0; $index -lt $lines.Count; $index++) {
+    if ($lines[$index] -match '^\s*\[data\.ghq\]\s*$') {
+      $sectionIndex = $index
+      break
+    }
   }
+
+  if ($sectionIndex -eq -1) {
+    if ($lines.Count -gt 0 -and $lines[$lines.Count - 1].Length -gt 0) {
+      $lines.Add('')
+    }
+    $lines.Add('[data.ghq]')
+    $lines.Add($rootSetting)
+  } else {
+    $nextSectionIndex = $lines.Count
+    for ($index = $sectionIndex + 1; $index -lt $lines.Count; $index++) {
+      if ($lines[$index] -match '^\s*\[') {
+        $nextSectionIndex = $index
+        break
+      }
+    }
+
+    $rootIndex = -1
+    for ($index = $sectionIndex + 1; $index -lt $nextSectionIndex; $index++) {
+      if ($lines[$index] -match '^\s*root\s*=') {
+        $rootIndex = $index
+        break
+      }
+    }
+
+    if ($rootIndex -eq -1) {
+      $lines.Insert($nextSectionIndex, $rootSetting)
+    } else {
+      $lines[$rootIndex] = $rootSetting
+    }
+  }
+
+  [IO.File]::WriteAllLines(
+    $ConfigPath,
+    $lines,
+    [Text.UTF8Encoding]::new($false)
+  )
   Write-Info "Windows ghq root: $resolvedRoot"
+  return $resolvedRoot
+}
+
+function Sync-WslGhqRoot {
+  param([Parameter(Mandatory)][string]$Root)
 
   if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
     Write-Warning 'WSL was not found; skipped WSL ghq root configuration.'
     return
   }
 
-  $wslRootOutput = & wsl.exe --exec wslpath -a -u $resolvedRoot 2>$null
+  $wslRootOutput = & wsl.exe --exec wslpath -a -u $Root 2>$null
   if ($LASTEXITCODE -ne 0 -or -not $wslRootOutput) {
     Write-Warning 'Could not convert the Windows ghq root to a WSL path.'
     return
@@ -164,8 +211,9 @@ if (-not $SkipApply) {
   }
 
   Initialize-ChezmoiConfig
+  $chezmoiConfigPath = Join-Path $HOME '.config\chezmoi\chezmoi.toml'
+  $resolvedGhqRoot = Write-GhqConfig -ConfigPath $chezmoiConfigPath -Root $GhqRoot
   if ($ConfigureWakaTime) {
-    $chezmoiConfigPath = Join-Path $HOME '.config\chezmoi\chezmoi.toml'
     Add-WakaTimeConfig -ConfigPath $chezmoiConfigPath
   }
   Write-Info 'Applying dotfiles with chezmoi'
@@ -176,7 +224,7 @@ if (-not $SkipApply) {
     throw "chezmoi apply failed with exit code $LASTEXITCODE."
   }
 
-  Set-GhqRoot -Root $GhqRoot
+  Sync-WslGhqRoot -Root $resolvedGhqRoot
 }
 
 Write-Info 'Windows dotfiles initialization complete'

--- a/initialize.ps1
+++ b/initialize.ps1
@@ -2,6 +2,7 @@
 param(
   [switch]$SkipPackages,
   [switch]$SkipApply,
+  [switch]$ConfigureWakaTime,
   [string]$GhqRoot = (Join-Path $HOME 'src')
 )
 
@@ -44,6 +45,49 @@ function Initialize-ChezmoiConfig {
     $config + [Environment]::NewLine,
     [Text.UTF8Encoding]::new($false)
   )
+}
+
+function Add-WakaTimeConfig {
+  param([Parameter(Mandatory)][string]$ConfigPath)
+
+  $configContent = [IO.File]::ReadAllText($ConfigPath)
+  if ($configContent -match '(?m)^\s*\[data\.wakatime\]\s*$') {
+    Write-Info 'Existing WakaTime configuration was preserved.'
+    return
+  }
+
+  $secureApiKey = Read-Host 'Enter your WakaTime API key' -AsSecureString
+  if ($secureApiKey.Length -eq 0) {
+    Write-Warning 'No WakaTime API key was entered; configuration was skipped.'
+    return
+  }
+
+  $apiKeyPointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureApiKey)
+  try {
+    $apiKey = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($apiKeyPointer)
+    $escapedApiKey = $apiKey.Replace('\', '\\').Replace('"', '\"')
+    $newLine = [Environment]::NewLine
+    $prefix = if ($configContent.Length -eq 0) {
+      ''
+    } elseif ($configContent.EndsWith("\n")) {
+      $newLine
+    } else {
+      $newLine + $newLine
+    }
+    $wakatimeConfig = @"
+[data.wakatime]
+  api_key = "$escapedApiKey"
+"@
+    [IO.File]::AppendAllText(
+      $ConfigPath,
+      $prefix + $wakatimeConfig.Trim() + $newLine,
+      [Text.UTF8Encoding]::new($false)
+    )
+  } finally {
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($apiKeyPointer)
+  }
+
+  Write-Info 'WakaTime API key was added to the local chezmoi config.'
 }
 
 function Set-GhqRoot {
@@ -120,6 +164,10 @@ if (-not $SkipApply) {
   }
 
   Initialize-ChezmoiConfig
+  if ($ConfigureWakaTime) {
+    $chezmoiConfigPath = Join-Path $HOME '.config\chezmoi\chezmoi.toml'
+    Add-WakaTimeConfig -ConfigPath $chezmoiConfigPath
+  }
   Write-Info 'Applying dotfiles with chezmoi'
   $chezmoiPath = $chezmoi.Source
   & $chezmoiPath apply --source $repositoryRoot --destination $HOME

--- a/run_onchange_install-skills.sh.tmpl
+++ b/run_onchange_install-skills.sh.tmpl
@@ -1,3 +1,4 @@
+{{ if ne .chezmoi.os "windows" -}}
 #!/bin/bash
 
 # Skillsfile hash: {{ include "Skillsfile" | sha256sum }}
@@ -20,3 +21,4 @@ if command -v gh >/dev/null 2>&1; then
         fi
     done < "{{ joinPath .chezmoi.sourceDir "Skillsfile" }}"
 fi
+{{ end -}}

--- a/winget-packages.json
+++ b/winget-packages.json
@@ -23,6 +23,7 @@
         { "PackageIdentifier": "sharkdp.fd" },
         { "PackageIdentifier": "Starship.Starship" },
         { "PackageIdentifier": "twpayne.chezmoi" },
+        { "PackageIdentifier": "Wakatime.CLIWakatime" },
         { "PackageIdentifier": "x-motemen.ghq" }
       ],
       "SourceDetails": {


### PR DESCRIPTION
## Summary

- manage the global mise configuration with chezmoi and preserve the existing `codex = "latest"` selection
- add a shared Starship configuration without changing the default prompt appearance
- add a shared PowerShell profile that initializes Starship and activates mise
- install safe profile loaders for Windows PowerShell 5.1 and PowerShell 7, including OneDrive Documents redirection

## Why

mise and Starship were installed on Windows, but only Windows PowerShell 5.1 initialized Starship and mise was not activated. WSL also had an unmanaged global Codex selection. This centralizes the shared configuration while keeping platform-specific caches and installed tool data outside chezmoi.

## Impact

After `chezmoi apply`, PowerShell 5.1 and PowerShell 7 load `~/.config/powershell/profile.ps1`. Existing empty profiles and the known one-line Starship profile are migrated to loaders; other customized profiles are preserved with a warning.

`codex = "latest"` does not update on shell startup or `chezmoi apply`. It follows the latest installed version and is updated explicitly with `mise upgrade codex`.

## Validation

- parsed the shared profile and rendered loader with the Windows PowerShell parser
- loaded the shared profile successfully in Windows PowerShell 5.1 and PowerShell 7
- loaded the mise config using an isolated state directory
- rendered a Starship prompt using an isolated cache directory
- `git diff --cached --check`