### PR TITLE
chore: delegate github auth to gh auth setup-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,18 @@ For example, to change the Git email address:
 ### Environment-Specific Data
 
 - Global defaults live in `chezmoidata.toml`; platform-specific files such as `chezmoidata.darwin.toml.tmpl` and `chezmoidata.linux.toml` layer on automatic values (e.g., the Homebrew prefix).
-- Sensitive or machine-local overrides can stay outside the repo: use `~/.config/chezmoi/chezmoi.toml` and nest keys under `[data]` to match the structure in `chezmoidata`. For the GitHub SSH key, set:
+- Sensitive or machine-local overrides can stay outside the repo: use `~/.config/chezmoi/chezmoi.toml` and nest keys under `[data]` to match the structure in `chezmoidata`.
 
-  ```toml
-  [data.ssh]
-    github_identity_file = "~/.ssh/your_custom_key"
-  ```
+### GitHub Authentication
 
-- `private_dot_ssh/config.tmpl` renders `Host github.com` and falls back to `~/.ssh/id_ed25519` when no `identity_file` override is defined.
+`~/.ssh/config` is **not** managed by this repository. GitHub authentication is delegated to the GitHub CLI:
+
+1. Authenticate once per machine: `gh auth login`
+2. `run_after_setup-git-credentials.sh` runs `gh auth setup-git` after every `chezmoi apply`, which registers `gh` as the git credential helper for GitHub over HTTPS.
+
+The script re-runs on each apply because applying rewrites `~/.gitconfig` from `dot_gitconfig.tmpl`, which is where `gh auth setup-git` stores its entries. It exits quietly when `gh` is missing or not authenticated, so first-time setup order does not matter — just re-run `chezmoi apply` after `gh auth login`.
+
+Run `gh config set git_protocol https` if you want git remotes to go through that credential helper. With the `ssh` protocol, `gh` keeps handing out SSH URLs and git authenticates with your default key (`~/.ssh/id_ed25519`) instead.
 
 ### Secret Management
 
@@ -70,7 +74,6 @@ Run the interactive setup script to create your configuration file:
 This script will prompt you for:
 - WakaTime API key (optional)
 - Email address override (optional)
-- Custom SSH key path (optional)
 - Machine profile (optional)
 
 #### Manual Setup
@@ -83,9 +86,6 @@ Alternatively, manually create or edit `~/.config/chezmoi/chezmoi.toml`:
 
 [data.user]
   email = "your-email@example.com"
-
-[data.ssh]
-  github_identity_file = "~/.ssh/your_custom_key"
 
 [data.machine]
   profile = "dev"
@@ -138,8 +138,8 @@ When hacking on the repository from a development clone, `./initialize.sh` ensur
 
 1. Clone the repository.
 2. Run `./initialize.sh`.
-3. Follow the prompts to configure your email, SSH key path, and other settings.
-   - For SSH keys on WSL, it's recommended to use **GitHub CLI** (`gh`) to create and manage your keys: `gh ssh-key add ~/.ssh/id_ed25519.pub`.
+3. Follow the prompts to configure your email and other settings.
+   - Run `gh auth login` so `gh auth setup-git` can wire up git credentials (see [GitHub Authentication](#github-authentication)).
 4. Switch to **zsh** if you haven't already: `chsh -s $(which zsh)`.
 
 ## Configuration Layout

--- a/private_dot_ssh/config.tmpl
+++ b/private_dot_ssh/config.tmpl
@@ -1,7 +1,0 @@
-{{- $ssh := default (dict) (get . "ssh") -}}
-{{- $githubIdentityFile := default "~/.ssh/id_ed25519" (get $ssh "github_identity_file") -}}
-Host github.com
-  HostName github.com
-  User git
-  IdentityFile {{$githubIdentityFile}}
-  IdentitiesOnly yes

--- a/run_after_setup-git-credentials.sh
+++ b/run_after_setup-git-credentials.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Configure GitHub authentication for git through the GitHub CLI.
+# This runs after every `chezmoi apply` on purpose: applying rewrites ~/.gitconfig
+# from dot_gitconfig.tmpl, which is also where `gh auth setup-git` stores its
+# credential helper entries. `gh auth setup-git` is idempotent.
+
+set -e
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "gh not found; skipping 'gh auth setup-git'."
+    exit 0
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "gh is not authenticated; run 'gh auth login' and then 'chezmoi apply' again."
+    exit 0
+fi
+
+echo "Configuring the git credential helper with 'gh auth setup-git'..."
+gh auth setup-git

--- a/setup-chezmoi-config.sh
+++ b/setup-chezmoi-config.sh
@@ -63,11 +63,6 @@ main() {
     email=${email:-9renpoto@gmail.com}
     echo
 
-    # SSH key path (optional override)
-    read -rp "Enter custom SSH key path for GitHub [~/.ssh/id_ed25519]: " github_ssh_key
-    github_ssh_key=${github_ssh_key:-~/.ssh/id_ed25519}
-    echo
-
     # Machine profile (optional)
     read -rp "Enter machine profile (e.g., dev, work, personal) [dev]: " machine_profile
     machine_profile=${machine_profile:-dev}
@@ -94,13 +89,6 @@ main() {
             echo ""
             echo "[data.wakatime]"
             echo "  api_key = \"$wakatime_api_key\""
-        fi
-
-        # SSH
-        if [ -n "${github_ssh_key:-}" ]; then
-            echo ""
-            echo "[data.ssh]"
-            echo "  github_identity_file = \"$github_ssh_key\""
         fi
 
         # Machine profile


### PR DESCRIPTION
## Intent

Stop managing `~/.ssh/config` with chezmoi and delegate GitHub authentication to `gh auth setup-git`.

`private_dot_ssh/config.tmpl` only pinned `IdentityFile` to the ssh default (`~/.ssh/id_ed25519`) plus `IdentitiesOnly yes`, so it carried a `[data.ssh]` config surface and an interactive prompt for almost no behavior. Existing ssh remotes keep working without it.

## Changes

- **Removed** `private_dot_ssh/config.tmpl`.
- **Added** `run_after_setup-git-credentials.sh`, which runs `gh auth setup-git`.
- **`setup-chezmoi-config.sh`**: dropped the SSH key prompt and the `[data.ssh]` block it emitted.
- **`README.md`**: new "GitHub Authentication" section; removed the `[data.ssh]` examples and the SSH-key-path mentions.

## Why `run_after_` and not `run_once_`

`gh auth setup-git` writes its credential helper entries into `~/.gitconfig`, which is exactly the file chezmoi rewrites from `dot_gitconfig.tmpl` on every apply. A `run_once_` script would be silently undone by the next `chezmoi apply`. `run_after_` re-runs after each apply and `gh auth setup-git` is idempotent.

The script exits 0 quietly when `gh` is missing or unauthenticated, so it is safe in CI (`check-chezmoi.sh` runs with `HOME` pointed at a temp dir) and in devcontainers, and the first-time setup order does not matter — just re-run `chezmoi apply` after `gh auth login`.

## Reviewer note

The credential helper is only exercised when git uses HTTPS remotes. With `gh config get git_protocol` set to `ssh`, `gh` keeps handing out SSH URLs and git authenticates with the default key instead. This is a machine-local setting, so it is documented in the README rather than forced by the repo.

## Validation

- `shellcheck run_after_setup-git-credentials.sh setup-chezmoi-config.sh initialize.sh` — pass
- `bash .devcontainer/scripts/check-chezmoi.sh` — exit 0 (doctor / apply / verify)
- `lefthook run pre-commit --all-files` — could not run locally: `bun` is not installed in this environment (`sh: bun: command not found`), so secretlint never started. The diff adds no secrets; relying on CI secretlint here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)