### PR TITLE
chore: keep repo tooling out of $HOME

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -6,6 +6,10 @@ SECURITY.md
 Skillsfile
 initialize.sh
 initialize.ps1
+devcontainer-setup.sh
+setup-chezmoi-config.sh
+scripts
+scripts/**
 lefthook.yml
 winget-packages.json
 .gitignore


### PR DESCRIPTION
## Intent

`chezmoi apply` currently installs repository tooling into `$HOME`. `.chezmoiignore` lists `initialize.sh` but not its siblings, so `chezmoi managed` includes:

```
devcontainer-setup.sh
scripts
scripts/chezmoi-init
setup-chezmoi-config.sh
```

On an existing machine that means `~/setup-chezmoi-config.sh` and `~/scripts/chezmoi-init` are sitting in the home directory, and `~/devcontainer-setup.sh` gets created on the next apply. All three are invoked from a development clone (`./setup-chezmoi-config.sh`, `./devcontainer-setup.sh`, `initialize.sh` → `$DOTFILES_ROOT/scripts/chezmoi-init`), never from `$HOME`.

## Changes

Added `devcontainer-setup.sh`, `setup-chezmoi-config.sh`, `scripts`, and `scripts/**` to the "Repository docs and tooling only" block of `.chezmoiignore`.

## Not changed

The `config/fish` / `config/nvim` entries are missing the leading dot for the rendered target, so they never matched — `.config/fish` and `.config/fish/config.fish` are managed and applied today despite the "Managed by package managers" comment. Correcting them would change which files land in `$HOME`, so that is left for a separate decision.

`lefthook.yml` is likewise stale (the file is `.lefthook.yml`), but source entries starting with `.` are ignored by chezmoi anyway, so it is harmless.

## Validation

Before / after `chezmoi managed --exclude=externals | grep -E '^(scripts|devcontainer|setup-)'`:

```
# before
devcontainer-setup.sh
scripts
scripts/chezmoi-init
setup-chezmoi-config.sh
setup-git-credentials.sh

# after
setup-git-credentials.sh
```

The remaining entry is the `run_after_setup-git-credentials.sh` script, which `chezmoi status` reports as `R` (run), not as a file to write.

- `bash .devcontainer/scripts/check-chezmoi.sh` — exit 0 (doctor / apply / verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)