### PR TITLE
fix: replace secretlint with gitleaks in the pre-commit hook

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,9 +27,9 @@ chezmoi update --apply                           # pull + apply in one step
 ./initialize.sh                                  # bootstrap (installs chezmoi + Brewfile)
 bash .devcontainer/scripts/check-chezmoi.sh     # validate templates (same as CI)
 
-bun install                                      # install JS toolchain (after cloning)
 lefthook install                                 # enable pre-commit hook
-lefthook run pre-commit --all-files              # run Secretlint manually
+gitleaks git --staged                            # scan staged changes (what the hook runs)
+gitleaks dir .                                   # scan the whole working tree
 
 brew bundle --file=Brewfile                      # install packages
 brew bundle check --file=Brewfile               # check drift

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,5 +1,6 @@
 pre-commit:
   commands:
-    secretlint:
-      glob: "*"
-      run: bun run secretlint -- {staged_files}
+    gitleaks:
+      # gitleaks is already a Brewfile dependency, so this needs no package
+      # manager or JS manifest.
+      run: gitleaks git --staged --redact --no-banner

--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -1,7 +1,0 @@
-{
-  "rules": [
-    {
-      "id": "@secretlint/secretlint-rule-preset-recommend"
-    }
-  ]
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,9 @@ chezmoi update --apply                           # pull + apply in one step
 ./initialize.sh                                  # bootstrap (installs chezmoi + Brewfile)
 bash .devcontainer/scripts/check-chezmoi.sh     # validate templates (same as CI)
 
-bun install                                      # install JS toolchain (after cloning)
 lefthook install                                 # enable pre-commit hook
-lefthook run pre-commit --all-files              # run Secretlint manually
+gitleaks git --staged                            # scan staged changes (what the hook runs)
+gitleaks dir .                                   # scan the whole working tree
 
 brew bundle --file=Brewfile                      # install packages
 brew bundle check --file=Brewfile               # check drift

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Use `chezmoidata.darwin.toml.tmpl` as a starting point when you need to pin macO
 - `brew bundle --file=Brewfile` keeps CLI/GUI packages in sync with the tracked Brewfile.
 - `brew bundle check --file=Brewfile` inspects for drift; pair with `brew bundle cleanup --file=Brewfile` to prune unused packages.
 - `winget import --import-file winget-packages.json --ignore-unavailable --ignore-versions` installs the Windows toolset.
-- `lefthook run pre-commit --all-files` runs Secretlint locally; enable the hook permanently with `lefthook install`.
+- `gitleaks git --staged` is what the pre-commit hook runs; enable the hook permanently with `lefthook install`. Use `gitleaks dir .` to scan the whole working tree.
 
 ## Working Locally
 


### PR DESCRIPTION
## Intent

`.lefthook.yml` runs `bun run secretlint`, which needs the `package.json` that `f623431` ("fix: remove unused") deleted along with `bun.lock`. Since then the hook has failed on every machine — `bun` was never reinstalled and there is no manifest to install from — and CI has no secretlint job either, so `--no-verify` was the only way to get a commit through.

## Change

Switch the hook to `gitleaks git --staged`. `gitleaks` is already a Brewfile dependency (unused until now), so this needs no package manager, no JS manifest, and no `bun install` step. Also removes `.secretlintrc.json` and updates the Secretlint/bun references in README.md, AGENTS.md, and .github/copilot-instructions.md.

## Validation

- Staged a file containing a GitHub-token-shaped string (`ghp_...`) and ran `git commit`: the hook caught it and blocked the commit (exit 1).
- Removed the leak and committed the real change: the hook ran `gitleaks git --staged`, found nothing, and the commit went through — no `--no-verify` needed.
- `bash .devcontainer/scripts/check-chezmoi.sh` — exit 0 (doctor / apply / verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)